### PR TITLE
Linked to source referenced in interactive example

### DIFF
--- a/docs/examples/interactive.md
+++ b/docs/examples/interactive.md
@@ -6,7 +6,7 @@ sidebar_label: Interactive
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-This is a comprehensive example that showcase what can be done by utilizing all the available features provided in MindAR. There is nothing new, so we will not go into the details. You can checkout the Demo and view the complete source for references.
+This is a comprehensive example that showcase what can be done by utilizing all the available features provided in MindAR. There is nothing new, so we will not go into the details. You can checkout the Demo and [view the complete source](https://github.com/hiukim/mind-ar-js-doc/blob/master/static/samples/advanced.html) for references.
 
 <a href={useBaseUrl('/samples/advanced.html')} target="_blank">Live Demo</a>
 


### PR DESCRIPTION
In the interactive example, viewing the example's source code is referenced. This adds a link to that source code so it is easier to reference directly.