### PR TITLE
Specify target image in Image Tracking Examples

### DIFF
--- a/docs/examples/event-handling.md
+++ b/docs/examples/event-handling.md
@@ -6,6 +6,7 @@ sidebar_label: Events Handling
 
 import {customFields} from '/docusaurus.config.js';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import cardImage from '@site/static/img/demo/card.png'
 
 :::note
 This section requires basic knowledge of web development
@@ -13,6 +14,10 @@ This section requires basic knowledge of web development
 
 ## Try it out
 To try this example, you need to run on desktop browser and open the development console to see the logs. <a href={useBaseUrl('/samples/events.html')} target="_blank">Live Demo</a>
+
+You can use the following target image for testing:
+
+<img src={cardImage} width="300" />
 
 We will go through the available events one by one in the following sub-sections. 
 

--- a/docs/examples/interactive.md
+++ b/docs/examples/interactive.md
@@ -5,10 +5,15 @@ sidebar_label: Interactive
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import cardImage from '@site/static/img/demo/card.png'
 
 This is a comprehensive example that showcase what can be done by utilizing all the available features provided in MindAR. There is nothing new, so we will not go into the details. You can checkout the Demo and view the complete source for references.
 
 <a href={useBaseUrl('/samples/advanced.html')} target="_blank">Live Demo</a>
+
+You can use the following target image for testing:
+
+<img src={cardImage} width="300" />
 
 ![img](/img/demo/interactive-demo.gif)
 


### PR DESCRIPTION
The documentation pages for "Events Handling" and "Interactive" examples do not clearly state what image is used for tracking.

This PR displays the target image, similar to the documentation pages for "Minimal" and "Basic" examples.